### PR TITLE
Fix AddRectanglePage.xaml.cs

### DIFF
--- a/src/presentation/Maui/LS.MAUIClient/Pages/Rectangles/AddRectanglePage.xaml.cs
+++ b/src/presentation/Maui/LS.MAUIClient/Pages/Rectangles/AddRectanglePage.xaml.cs
@@ -6,7 +6,7 @@ namespace LS.MAUIClient.Pages.Rectangles;
 [QueryProperty(nameof(Id), "Id")]
 partial class AddRectanglePage : ContentPage
 {
-	public string Id { get; set; }
+    //public string Id { get; set; } // this string causes exception System.Reflection.AmbiguousMatchException
     private readonly AddRectangleViewModel _addRectangleViewModel;
     public AddRectanglePage(AddRectangleViewModel addRectangleViewModel)
 	{


### PR DESCRIPTION
Fixed overlapping of Element.Id, which caused exception "System.Reflection.AmbiguousMatchException".
<img width="628" alt="exception" src="https://github.com/windofny1/LearnStart/assets/115996702/10f53ec3-9676-41af-b268-36839bf29efa">
